### PR TITLE
Add form action hard reset and update use address bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steroidsjs/core",
-  "version": "2.2.64",
+  "version": "2.2.65",
   "description": "",
   "author": "Vladimir Kozhin <hello@kozhindev.com>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steroidsjs/core",
-  "version": "2.2.63",
+  "version": "2.2.64",
   "description": "",
   "author": "Vladimir Kozhin <hello@kozhindev.com>",
   "repository": {

--- a/src/actions/form.ts
+++ b/src/actions/form.ts
@@ -1,6 +1,7 @@
 export const FORM_INITIALIZE = '@form/initialize';
 export const FORM_CHANGE = '@form/change';
 export const FORM_RESET = '@form/reset';
+export const FORM_HARD_RESET = '@form/hard_reset';
 export const FORM_DESTROY = '@form/destroy';
 export const FORM_SET_ERRORS = '@form/set_errors';
 export const FORM_SUBMIT = '@form/submit';
@@ -68,6 +69,15 @@ export const formSetSubmitting = (formId, isSubmitting) => ({
  */
 export const formReset = (formId) => ({
     type: FORM_RESET,
+    formId,
+});
+
+/**
+ * Полный сброс значений формы
+ * @param formId
+ */
+export const formHardReset = (formId) => ({
+    type: FORM_HARD_RESET,
     formId,
 });
 

--- a/src/actions/form.ts
+++ b/src/actions/form.ts
@@ -73,7 +73,7 @@ export const formReset = (formId) => ({
 });
 
 /**
- * Полный сброс значений формы
+ * Сброс данных формы, включая первоначальное состояние (initialValues)
  * @param formId
  */
 export const formHardReset = (formId) => ({

--- a/src/hooks/useAddressBar.tsx
+++ b/src/hooks/useAddressBar.tsx
@@ -1,4 +1,5 @@
 import _get from 'lodash-es/get';
+import _isEmpty from 'lodash-es/isEmpty';
 import queryString from 'query-string';
 import {replace} from 'connected-react-router';
 import _toInteger from 'lodash-es/toInteger';
@@ -147,14 +148,14 @@ export default function useAddressBar(config: IAddressBarConfig): IAddressBarOut
     const updateQuery = useCallback(values => {
         if (config.enable) {
             const normalizedValues = Object.keys(values).reduce((obj, key) => {
-                if (values[key] !== undefined) {
+                if (values[key] !== undefined && !_isEmpty(values[key])) {
                     obj[key] = values[key];
                 }
                 return obj;
             }, {});
             if (!_isEqual(initialQueryRef.current, normalizedValues)) {
                 initialQueryRef.current = normalizedValues;
-                dispatch(queryReplace(config.model, location, values, config.useHash));
+                dispatch(queryReplace(config.model, location, normalizedValues, config.useHash));
             }
         }
     }, [config.enable, config.model, config.useHash, dispatch, location]);

--- a/src/reducers/form.ts
+++ b/src/reducers/form.ts
@@ -11,8 +11,10 @@ import {
     FORM_SUBMIT,
     FORM_SET_SUBMITTING,
     FORM_RESET,
+    FORM_HARD_RESET,
     FORM_ARRAY_ADD,
-    FORM_ARRAY_REMOVE, FORM_DESTROY,
+    FORM_ARRAY_REMOVE,
+    FORM_DESTROY,
 } from '../actions/form';
 
 /**
@@ -71,6 +73,16 @@ export function reducerItem(state, action) {
             return {
                 ...state,
                 values: _cloneDeep(state.initialValues || {}),
+            };
+
+        case FORM_HARD_RESET:
+            return {
+                ...state,
+                initialValues: null,
+                values: {},
+                errors: {},
+                isInvalid: false,
+                isSubmitting: false,
             };
 
         case FORM_DESTROY:


### PR DESCRIPTION
- Добавил экшн `formHardReset`, так как имеющийся `formReset` сбрасывал форму до `initialValues`
- Обновил хук `useAddressBar`

---

Пояснения к обновлению хука:

Появилась проблема - после выбора в форме значений, которые имеют тип `string[]`, например - тип объекта недвижимости, или количество комнат, при сбросе формы в query params адресной строки оставалась строка вида `?categories=&roomsAmount=`, то есть в строку добавляются пустые массивы.

Причина - логика работы хука `useAddressBar` внутри `Form`.

Внутри проверяются текущие значения формы, для нахождения разницы и обновления параметров адресной строки. Однако выполняется лишь проверка на не равенство undefined - `values[key] !== undefined`. При этом пустые массивы принимаются как валидные значения, успешно проходя данную проверку.

Пустой массив образуется, например, в `DropDownField`, если с флагом `multiple` выбрать несколько значений, а потом сделать обратное, в форму запишется пустой массив, а затем и в адресную строку.