### PR TITLE
Fix values filtering in use address bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steroidsjs/core",
-  "version": "2.2.65",
+  "version": "2.2.66",
   "description": "",
   "author": "Vladimir Kozhin <hello@kozhindev.com>",
   "repository": {

--- a/src/hooks/useAddressBar.tsx
+++ b/src/hooks/useAddressBar.tsx
@@ -148,8 +148,12 @@ export default function useAddressBar(config: IAddressBarConfig): IAddressBarOut
     const updateQuery = useCallback(values => {
         if (config.enable) {
             const normalizedValues = Object.keys(values).reduce((obj, key) => {
-                if (values[key] !== undefined && !_isEmpty(values[key])) {
-                    obj[key] = values[key];
+                const value = values[key];
+                const isValidValue = typeof value === 'object'
+                    ? !_isEmpty(value)
+                    : value !== undefined;
+                if (isValidValue) {
+                    obj[key] = value;
                 }
                 return obj;
             }, {});

--- a/src/hooks/useAddressBar.tsx
+++ b/src/hooks/useAddressBar.tsx
@@ -147,6 +147,7 @@ export default function useAddressBar(config: IAddressBarConfig): IAddressBarOut
     const dispatch = useDispatch();
     const updateQuery = useCallback(values => {
         if (config.enable) {
+            // Remove all 'undefined' values or empty objects/arrays from passed form values
             const normalizedValues = Object.keys(values).reduce((obj, key) => {
                 const value = values[key];
                 const isValidValue = typeof value === 'object'


### PR DESCRIPTION
Предыдущее обновление `useAddressBar` прошло с ошибкой - фильтрация значений формы стала пропускать только НЕ пустые массивы и объекты, примитивные типы данных (числа, строки) стали просто отбрасываться.

Исправил логику фильтрации.