### PR TITLE
Fix getting categories with missing items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
  "name": "@steroidsjs/core",
-"version": "3.0.0-beta.31",
+"version": "3.0.0-beta.32",
  "description": "",
  "author": "Vladimir Kozhin <hello@kozhindev.com>",
  "repository": {

--- a/src/ui/form/AutoCompleteField/AutoCompleteField.tsx
+++ b/src/ui/form/AutoCompleteField/AutoCompleteField.tsx
@@ -55,13 +55,18 @@ export interface IAutoCompleteFieldViewProps extends Omit<IAutoCompleteFieldProp
     onItemHover: (id: PrimaryKey | any) => void,
 }
 
-const getCategories = (items) => items.reduce((allCategories, item) => {
-    if (item.category && !allCategories.includes(item.category)) {
-        allCategories.push(item.category);
+const getCategories = (items) => {
+    if (!items) {
+        return [];
     }
+    return items.reduce((allCategories, item) => {
+        if (item.category && !allCategories.includes(item.category)) {
+            allCategories.push(item.category);
+        }
 
-    return allCategories;
-}, []);
+        return allCategories;
+    }, []);
+};
 
 function AutoCompleteField(props: IAutoCompleteFieldProps & IFieldWrapperOutputProps): JSX.Element {
     const components = useComponents();


### PR DESCRIPTION
You also should write tests in case using `AutoCompleteField` with `dataProvider` props. In this case you don't pass `items` prop to `AutoCompleteField`. Also `items` can be Enum - string