### PR TITLE
fix Number and Text fields cursor bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
  "name": "@steroidsjs/core",
-"version": "3.0.0-beta.69",
+"version": "3.0.0-beta.70",
  "description": "",
  "author": "Vladimir Kozhin <hello@kozhindev.com>",
  "repository": {

--- a/src/ui/form/AutoCompleteField/AutoCompleteField.tsx
+++ b/src/ui/form/AutoCompleteField/AutoCompleteField.tsx
@@ -167,7 +167,7 @@ function AutoCompleteField(props: IAutoCompleteFieldProps & IFieldWrapperOutputP
         ...props.inputProps,
         type: 'text',
         name: props.input.name,
-        value: props.input.value || '',
+        defaultValue: props.input.value ?? '',
         placeholder: props.placeholder,
         disabled: props.disabled,
         onChange,

--- a/src/ui/form/InputField/InputField.tsx
+++ b/src/ui/form/InputField/InputField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {ReactNode, useMemo} from 'react';
+import {InputHTMLAttributes, ReactNode, useMemo} from 'react';
 import {useMaskito} from '@maskito/react';
 import {MaskitoOptions} from '@maskito/core';
 import {maskitoDateOptionsGenerator} from '@maskito/kit';
@@ -48,7 +48,7 @@ export interface IBaseFieldProps extends IFieldWrapperInputProps, IUiComponent {
      * Свойства для элемента input
      * @example {onKeyDown: ...}
      */
-    inputProps?: any;
+    inputProps?: InputHTMLAttributes<HTMLInputElement>;
 
     /**
      * Показывать иконку очищения поля
@@ -129,7 +129,7 @@ export interface IInputFieldViewProps extends IInputFieldProps, IFieldWrapperOut
         onChange: (value: any) => void,
         value: string | number,
         placeholder: string,
-        disabled: string,
+        disabled: boolean,
     },
     onClear?: () => void,
     onFocus?: (e: Event | React.FocusEvent) => void,

--- a/src/ui/form/NumberField/NumberField.ts
+++ b/src/ui/form/NumberField/NumberField.ts
@@ -47,7 +47,7 @@ function NumberField(props: INumberFieldProps & IFieldWrapperOutputProps): JSX.E
 
     props.inputProps = useMemo(() => ({
         name: props.input.name,
-        value: props.input.value ?? '',
+        defaultValue: props.input.value ?? '',
         onChange: value => props.input.onChange(value),
         type: 'number',
         min: props.min,

--- a/src/ui/form/NumberField/NumberField.ts
+++ b/src/ui/form/NumberField/NumberField.ts
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {ChangeEvent, useMemo} from 'react';
 import {IBaseFieldProps} from '../InputField/InputField';
 import {useComponents} from '../../../hooks';
 import fieldWrapper, {IFieldWrapperOutputProps} from '../Field/fieldWrapper';
@@ -32,7 +32,7 @@ export interface INumberFieldViewProps extends INumberFieldProps, IFieldWrapperO
     inputProps: {
         type: string,
         name: string,
-        onChange: (value: string) => void,
+        onChange: (value: ChangeEvent<HTMLInputElement> | string) => void,
         value: number,
         placeholder: string,
         disabled: boolean,

--- a/src/ui/form/PasswordField/PasswordField.ts
+++ b/src/ui/form/PasswordField/PasswordField.ts
@@ -75,7 +75,7 @@ function PasswordField(props: IPasswordFieldProps & IFieldWrapperOutputProps): J
 
     props.inputProps = useMemo(() => ({
         name: props.input.name,
-        value: props.input.value || '',
+        defaultValue: props.input.value ?? '',
         onChange: e => props.input.onChange(e.target ? e.target.value : e.nativeEvent.text),
         type,
         placeholder: props.placeholder,

--- a/src/ui/form/TextField/TextField.ts
+++ b/src/ui/form/TextField/TextField.ts
@@ -53,7 +53,7 @@ function TextField(props: ITextFieldProps & IFieldWrapperOutputProps): JSX.Eleme
 
     const inputProps = useMemo(() => ({
         name: props.input.name,
-        value: props.input.value || '',
+        defaultValue: props.input.value ?? '',
         onChange,
         onKeyUp,
         placeholder: props.placeholder,

--- a/src/ui/form/TextField/TextField.ts
+++ b/src/ui/form/TextField/TextField.ts
@@ -19,7 +19,7 @@ export interface ITextFieldViewProps extends ITextFieldProps, IFieldWrapperOutpu
     inputProps: {
         name: string,
         onChange: (value: string | ChangeEvent) => void,
-        onKeyUp: KeyboardEventHandler<HTMLTextAreaElement>,
+        onKeyUp: KeyboardEventHandler,
         value: string | number,
         placeholder: string,
         disabled: boolean,


### PR DESCRIPTION
Два месяца назад в [коммите](https://github.com/steroids/react/commit/cf81e79313707bd2f348f1e6ab4e00c0ed3f6a29) был исправлен баг компонента `InputField`. Баг был связан с тем, что при вводе значения в `InputField` курсор каждый раз отбрасывало в конец строки. 

Однако та же проблема осталась в компонентах `NumberField` и `TextField`. 

смысл этого PR - в решении того же бага в компонентах `NumberField` и `TextField`. 