### PR TITLE
v3.0.0-beta.74 fix router params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
  "name": "@steroidsjs/core",
-"version": "3.0.0-beta.73",
+"version": "3.0.0-beta.74",
  "description": "",
  "author": "Vladimir Kozhin <hello@kozhindev.com>",
  "repository": {


### PR DESCRIPTION
**Как воспроизвести:**

1. Добавить два маршрута. Один обычный другой с ролью role=ROUTER_ROLE_MODAL


```js
[ROUTE_BOOK_DICTIONARY]: {
    exact: false,
    path: 'book/dictionary',
    component: DictionaryPage,
    label: __('Словарь'),
    roles: permissions,
    items: {
        [ROUTE_BOOK_DICTIONARY_ARTICLE]: {
            exact: false,
            path: 'book/dictionary/:articleId',
            role: ROUTER_ROLE_MODAL,
            component: ArticleModal,
            label: __('Статья'),
            roles: permissions,
        },
    }
},
```

**Что делаю:**

2. Перейти с маршрута  `book/dictionary` на `book/dictionary/1`
3. Нажать системную кнопку "назад" в браузере.

**Что ожидаю:**

Маршрут изменяется с `book/dictionary/1` на `book/dictionary`

**Что происходит:**

Маршрут изменяется с `book/dictionary/1` на `book/dictionary?articleId=1`
