### PR TITLE
steroids/dev#735: FieldList. itemViewProps and default onRemove prop conflict fix

### DIFF
--- a/src/ui/form/FieldList/FieldList.tsx
+++ b/src/ui/form/FieldList/FieldList.tsx
@@ -287,8 +287,8 @@ function FieldList(props: IFieldListProps & IFieldWrapperOutputProps): JSX.Eleme
 
     const itemViewProps = useMemo(() => ({
         ...commonProps,
-        ...props.itemViewProps,
         onRemove,
+        ...props.itemViewProps,
         removeIcon: props.removeIcon,
     }), [commonProps, onRemove, props.itemViewProps, props.removeIcon]);
 


### PR DESCRIPTION
Стандартный onRemove callback перезатирал onRemove, который передавался из props