### PR TITLE
728 number field bug

### DIFF
--- a/src/hooks/useSaveCursorPosition.tsx
+++ b/src/hooks/useSaveCursorPosition.tsx
@@ -1,10 +1,5 @@
-/* eslint-disable max-len */
-/* eslint-disable no-unneeded-ternary */
-/* eslint-disable consistent-return */
-/* eslint-disable no-return-assign */
-/* eslint-disable no-unused-expressions */
+import _isNull from 'lodash/isNull';
 import React, {ChangeEvent} from 'react';
-import _isNull from 'lodash-es/isNull';
 import {IInputParams} from '../ui/form/Field/fieldWrapper';
 
 export default function useSaveCursorPosition(
@@ -22,13 +17,14 @@ export default function useSaveCursorPosition(
     }, [cursor, inputParams.value]);
 
     const onChange = React.useCallback((event: ChangeEvent<HTMLInputElement>, value = null) => {
+        const newValue = _isNull(value) ? event.target?.value : value;
         if (onChangeCallback) {
-            onChangeCallback(value || event.target?.value);
+            onChangeCallback(newValue);
         }
 
         setCursor(event?.target?.selectionStart);
 
-        inputParams.onChange(value || event.target?.value);
+        inputParams.onChange(newValue);
     }, [inputParams, onChangeCallback]);
 
     return {

--- a/src/ui/form/NumberField/NumberField.ts
+++ b/src/ui/form/NumberField/NumberField.ts
@@ -1,8 +1,8 @@
 /* eslint-disable max-len */
-import React, {ChangeEvent, useMemo, useCallback} from 'react';
-import {IBaseFieldProps} from '../InputField/InputField';
+import React, {ChangeEvent, useCallback, useMemo} from 'react';
 import {useComponents, useSaveCursorPosition} from '../../../hooks';
 import fieldWrapper, {IFieldWrapperInputProps, IFieldWrapperOutputProps} from '../Field/fieldWrapper';
+import {IBaseFieldProps} from '../InputField/InputField';
 import useInputTypeNumber from './hooks/useInputTypeNumber';
 
 const DEFAULT_STEP = 1;
@@ -63,7 +63,11 @@ export interface INumberFieldViewProps extends INumberFieldProps, IFieldWrapperO
 function NumberField(props: INumberFieldProps & IFieldWrapperOutputProps): JSX.Element {
     const components = useComponents();
 
-    const {inputRef: currentInputRef, onChange} = useSaveCursorPosition(props.input, props.onChange);
+    const {inputRef: currentInputRef, onChange: _onChange} = useSaveCursorPosition(props.input, props.onChange);
+
+    const onChange = useCallback((event:ChangeEvent<HTMLInputElement>, value?: any) => {
+        _onChange(event, Number(value ?? event.target.value));
+    }, [_onChange]);
 
     const step = React.useMemo(() => props.step ?? DEFAULT_STEP, [props.step]);
 
@@ -92,7 +96,7 @@ function NumberField(props: INumberFieldProps & IFieldWrapperOutputProps): JSX.E
             newValue = fixToDecimal(currentValue - step);
         }
 
-        onChange(null, String(newValue));
+        onChange(null, newValue);
     }, [currentInputRef, onChange, props.decimal, step]);
 
     const onStepUp = useCallback(() => {

--- a/src/ui/form/NumberField/NumberField.ts
+++ b/src/ui/form/NumberField/NumberField.ts
@@ -66,7 +66,8 @@ function NumberField(props: INumberFieldProps & IFieldWrapperOutputProps): JSX.E
     const {inputRef: currentInputRef, onChange: _onChange} = useSaveCursorPosition(props.input, props.onChange);
 
     const onChange = useCallback((event:ChangeEvent<HTMLInputElement>, value?: any) => {
-        _onChange(event, Number(value ?? event.target.value));
+        const newValue = value ?? event.target.value;
+        _onChange(event, newValue === '' ? '' : Number(newValue));
     }, [_onChange]);
 
     const step = React.useMemo(() => props.step ?? DEFAULT_STEP, [props.step]);
@@ -100,16 +101,21 @@ function NumberField(props: INumberFieldProps & IFieldWrapperOutputProps): JSX.E
     }, [currentInputRef, onChange, props.decimal, step]);
 
     const onStepUp = useCallback(() => {
-        if (!(Number(currentInputRef.current.value) + step > props.max)) {
+        const newValue = Number(currentInputRef.current.value) + step;
+        const isLessThanMaximum = !(newValue > props.max);
+        if (isLessThanMaximum) {
             onStep(true);
         }
     }, [currentInputRef, onStep, props.max, step]);
 
     const onStepDown = useCallback(() => {
-        if (!(Number(currentInputRef.current.value) - step < props.min)) {
+        const newValue = Number(currentInputRef.current.value) - step;
+        const isMoreThanMinimum = !(newValue < props.min);
+        const isNegative = !(!props.isCanBeNegative && newValue < 0);
+        if (isMoreThanMinimum && isNegative) {
             onStep(false);
         }
-    }, [currentInputRef, onStep, props.min, step]);
+    }, [currentInputRef, onStep, props.min, props.isCanBeNegative, step]);
 
     const onKeyDown = useCallback((event: KeyboardEvent) => {
         if (event.key === 'ArrowUp') {


### PR DESCRIPTION
https://gitlab.kozhindev.com/steroids/dev/-/issues/728
Не уверен, что за "один баг, возникший при переходе на React 18" из задачи, возможно он вернулся.
С этим MR NumberField хранит в редаксе значение с типом number, а также отправляет в запросах также number.
Пока был рядом убрал возможность стрелочкой вниз указать отрицательное число, если isCanBeNegative === false 