### PR TITLE
steroids/dev#726 Баг в роутинге

### DIFF
--- a/src/ui/nav/Router/Router.tsx
+++ b/src/ui/nav/Router/Router.tsx
@@ -206,7 +206,11 @@ const renderComponent = (route: IRouteItem, activePath, routeProps, alwaysAppend
         }
 
         // Check already redirected
-        const toPath = redirectPath + routeProps.location.search;
+        const toPath = (
+            alwaysAppendParentRoutePath
+                ? redirectPath
+                : buildUrl(redirectPath, routeProps?.match?.params)
+        ) + routeProps.location.search;
         if (activePath !== toPath) {
             return (
                 <Redirect

--- a/src/ui/nav/Router/Router.tsx
+++ b/src/ui/nav/Router/Router.tsx
@@ -206,7 +206,7 @@ const renderComponent = (route: IRouteItem, activePath, routeProps, alwaysAppend
         }
 
         // Check already redirected
-        const toPath = buildUrl(redirectPath, routeProps?.match?.params);
+        const toPath = redirectPath + routeProps.location.search;
         if (activePath !== toPath) {
             return (
                 <Redirect

--- a/src/ui/nav/Router/Router.tsx
+++ b/src/ui/nav/Router/Router.tsx
@@ -210,7 +210,7 @@ const renderComponent = (route: IRouteItem, activePath, routeProps, alwaysAppend
             alwaysAppendParentRoutePath
                 ? redirectPath
                 : buildUrl(redirectPath, routeProps?.match?.params)
-        ) + routeProps.location.search;
+        );
         if (activePath !== toPath) {
             return (
                 <Redirect


### PR DESCRIPTION
Если я правильно понял

В роутере при построении пути для редиректа использовалась функция buildUrl: 

```tsx
export const buildUrl = (path, params: TUrlParams = null) => {
    // Get url
    let url = path;
    let pathKeys = [];
    try {
        pathKeys = parse(path)
            .map((p: any) => typeof p === 'object' && p.name)
            .filter(Boolean);
        url = compile(path)({
            ...params,
        });
    } catch (e) {
        // eslint-disable-line no-empty
    }

    // Append params, which keys is not included in path keys
    const queryObj = {};
    Object.keys(params || {})
        .filter(key => !pathKeys.includes(key))
        .forEach(key => {
            queryObj[key] = params[key];
        });
    const query = queryString.stringify(queryObj);
    if (!_isEmpty(query) && url) {
        url = url + (url.indexOf('?') !== -1 ? '&' : '?') + query;
    }

    return url;
};
```

Которая если в первом аргументе есть routeParams заполняет ими, а все оставшиеся записывает в searchParams.

В фурнкции renderComponent:
```tsx
const renderComponent = (route: IRouteItem, activePath, routeProps, alwaysAppendParentRoutePath) => {
    const routePath = buildUrl(route.path, routeProps?.match?.params);

    if (route.redirectTo && routePath === activePath) {
        const redirectPath = alwaysAppendParentRoutePath
            ? findRedirectPathRecursive(route, activePath)
            : findRedirectPathRecursive(route);

        if (redirectPath === null) {
            // eslint-disable-next-line no-console
            console.error('Not found path for redirect in route:', route);
            return null;
        }

        // Check already redirected
        const toPath = buildUrl(redirectPath, routeProps?.match?.params);
        if (activePath !== toPath) {
            return (
                <Redirect
                    {...routeProps}
                    to={toPath}
                    {...route.componentProps}
                />
            );
        }
    }

    if (!route.component) {
        return null;
    }

    const Component = route.component;

    return (
        <Component
            {...routeProps}
            {...route.componentProps}
        />
    );
};
```

Изначально:
```tsx
 const redirectPath = alwaysAppendParentRoutePath
            ? findRedirectPathRecursive(route, activePath)
            : findRedirectPathRecursive(route);
```

в случае alwaysAppendParentRoutePath=true, redirectPath = '/test/3',
а в случае false, redirectPath = '/test/:id'.

Поэтому, когда мы вызываем buildUrl(redirectPath, params)

в случае true, в изначальной строке нет параметров и из-за этого buildPath записывает эти параметры в searchParams.

Чтобы решить эту проблему, изменил
```tsx
 // Check already redirected
        const toPath = buildUrl(redirectPath, routeProps?.match?.params);
        if (activePath !== toPath) {
            return (
                <Redirect
                    {...routeProps}
                    to={toPath}
                    {...route.componentProps}
                />
            );
        }
```
на 
```tsx
// Check already redirected
        const toPath = (
            alwaysAppendParentRoutePath
                ? redirectPath
                : buildUrl(redirectPath, routeProps?.match?.params)
        ) + routeProps.location.search;
        if (activePath !== toPath) {
            return (
                <Redirect
                    {...routeProps}
                    to={toPath}
                    {...route.componentProps}
                />
            );
        }
```