### PR TITLE
steroids/dev#771 Bug: GridColumn.sortable отсутсвуют иконки      

### DIFF
--- a/src/hooks/useList.tsx
+++ b/src/hooks/useList.tsx
@@ -274,6 +274,7 @@ export interface IListOutput {
     renderInfiniteScroll: () => any,
     onFetch: (params?: Record<string, unknown>) => void,
     onSort: (value: any) => void,
+    sort?: string,
 }
 
 export const defaultConfig = {
@@ -620,5 +621,6 @@ export default function useList(config: IListConfig): IListOutput {
         renderInfiniteScroll,
         onFetch,
         onSort,
+        sort: formValues?.sort,
     };
 }

--- a/src/ui/list/Grid/Grid.tsx
+++ b/src/ui/list/Grid/Grid.tsx
@@ -239,6 +239,7 @@ export interface IGridViewProps extends Omit<IGridProps, 'onFetch'> {
 
 export default function Grid(props: IGridProps): JSX.Element {
     const components = useComponents();
+
     const {
         list,
         model,
@@ -256,6 +257,7 @@ export default function Grid(props: IGridProps): JSX.Element {
         renderInfiniteScroll,
         onFetch,
         onSort,
+        sort,
     } = useList({
         listId: props.listId,
         primaryKey: props.primaryKey,
@@ -383,6 +385,7 @@ export default function Grid(props: IGridProps): JSX.Element {
         columns,
         onFetch,
         onSort,
+        sort,
         items: list?.items || [],
         searchForm: props.searchForm,
         listId: props.listId,
@@ -393,7 +396,8 @@ export default function Grid(props: IGridProps): JSX.Element {
         primaryKey: props.primaryKey,
     }), [list, paginationPosition, paginationSizePosition, layoutNamesPosition, renderList, renderLoading, renderEmpty,
         renderPagination, renderPaginationSize, renderLayoutNames, renderSearchForm, renderInfiniteScroll, renderValue, columns,
-        onFetch, onSort, props.searchForm, props.listId, props.isLoading, props.size, props.hasAlternatingColors, props.className, props.primaryKey]);
+        onFetch, onSort, sort, props.searchForm, props.listId, props.isLoading, props.size, props.hasAlternatingColors, props.className,
+        props.primaryKey]);
 
     return components.ui.renderView(props.view || 'list.GridView', viewProps);
 }


### PR DESCRIPTION
Было:

![Снимок экрана 2025-04-11 в 13 56 10](https://github.com/user-attachments/assets/e8bb3fe5-c517-42d9-bdf6-089fb13c0f99)

![Снимок экрана 2025-04-11 в 13 56 20](https://github.com/user-attachments/assets/9dfcffd8-5958-4f73-a265-14254d879a8b)

Стало: 

![Снимок экрана 2025-04-11 в 13 54 45](https://github.com/user-attachments/assets/47b29ca6-c22a-438c-a3ff-ae33b068f243)

![Снимок экрана 2025-04-11 в 13 54 58](https://github.com/user-attachments/assets/24cdd03a-4a2e-49e2-bbec-bdfe8aa6d3ab)

Совместно [с этим ПР](https://github.com/steroids/react-bootstrap/pull/251)