### PR TITLE
steroids/dev#903: Рассинхрон в инициализации и обновлении локального routes в Router.tsx

### DIFF
--- a/src/ui/nav/Router/Router.tsx
+++ b/src/ui/nav/Router/Router.tsx
@@ -284,8 +284,8 @@ function Router(props: IRouterProps): JSX.Element {
     // Routes state
     const [routes, setRoutes] = useState(treeToList(props.routes, true, null, props.alwaysAppendParentRoutePath));
     useUpdateEffect(() => {
-        setRoutes(props.routes);
-    }, [props.routes]);
+        setRoutes(treeToList(props.routes, true, null, props.alwaysAppendParentRoutePath));
+    }, [props.alwaysAppendParentRoutePath, props.routes]);
 
     // Fix end slash on switch to base route
     useUpdateEffect(() => {


### PR DESCRIPTION
Локальное состояние routes в Route.tsx на первом рендере инициализируется прогоном props.routes через treeToList, а при обновлении props.routes в routes снова попадает сырое дерево. В этот момент компонент начинает работать с объектом как с массивом и падает ошибка.

Заменил

```ts
        setRoutes(props.routes)
```
на 
```ts
        setRoutes(treeToList(props.routes, true, null, props.alwaysAppendParentRoutePath));
```

ошибка ушла, приложение работает корректно 
